### PR TITLE
Add support for aggregate_failures

### DIFF
--- a/lib/test_recorder/rspec.rb
+++ b/lib/test_recorder/rspec.rb
@@ -9,18 +9,28 @@ module TestRecorder
       attr_accessor :cdp_recorder
 
       def after_failed_example(example)
-        if example.exception
+        if passed?(example)
+          cdp_recorder.stop_and_discard
+        else
           video_path = cdp_recorder.stop_and_save("failures_#{method_name(example)}.webm").to_s
           if File.exist?(video_path)
             example.metadata[:extra_failure_lines] = [example.metadata[:extra_failure_lines], "[Video]: #{video_path}"].flatten
           end
-        else
-          cdp_recorder.stop_and_discard
         end
       end
 
       def method_name(example)
         example.description.underscore.tr(CHARS_TO_TRANSLATE.join, "_")[0...200] + "_#{rand(1000)}"
+      end
+
+      def passed?(example)
+        return false if example.exception
+        return true unless defined?(::RSpec::Expectations::FailureAggregator)
+
+        failure_notifier = ::RSpec::Support.failure_notifier
+        return true unless failure_notifier.is_a?(::RSpec::Expectations::FailureAggregator)
+
+        failure_notifier.failures.empty? && failure_notifier.other_errors.empty?
       end
     end
   end

--- a/test/dummy/spec/system/todos_spec.rb
+++ b/test/dummy/spec/system/todos_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe "Todos", type: :system do
     expect(page).to have_text "Todo successfully created"
   end
 
+  it "with aggregate failures", :aggregate_failures do
+    visit "/todos"
+    click_on "New todo"
+
+    fill_in "Title", with: "Todo Title"
+    expect(page).to have_text "foobar"
+    click_on "Create Todo"
+
+    expect(page).to have_text "Todo successfully created"
+  end
+
   it "with retry", retry: 2 do
     visit "/todos"
     click_on "New todo"

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -29,6 +29,10 @@ class TestRecorderTest < Minitest::Test
         refute files.size.zero?
         assert File.size(files.first).positive?
 
+        files = Dir.glob("tmp/videos/failures_with_aggregate_failures_*.webm")
+        refute files.size.zero?
+        assert File.size(files.first).positive?
+
         files = Dir.glob("tmp/videos/failures_with_retry_*.webm")
         refute files.size.zero?
         assert File.size(files.first).positive?


### PR DESCRIPTION
test-recorder doesn't work as expected when RSpec's [aggregate_failures feature](https://rspec.info/features/3-12/rspec-core/expectation-framework-integration/aggregating-failures/) enable because `example.exception` is false even if the spec fail.

Fix this problem by referring to the workaround used by rspec-rails

ref: https://github.com/rspec/rspec-rails/commit/95f4522c0549a32de59c19eb9b5f9a72126a9eb6